### PR TITLE
fixed jleagle/packagist-api-client#2 - PHP 8.1 Deprecation - Illuminate\Support\Collection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
   "require": {
     "php": ">=5.4.0",
     "jleagle/curl-wrapper": "~0.1",
-    "vinelab/rss": "^1.0"
+    "vinelab/rss": "^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.0"
+    "phpunit/phpunit": "^9.3.0"
   },
   "repositories": [
     {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,25 +3,14 @@
          bootstrap="vendor/autoload.php"
          colors="true"
          verbose="true"
-         strict="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
   <testsuites>
-    <testsuite>
+    <testsuite name="Default">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-    </whitelist>
-    <blacklist>
-      <directory suffix=".php">vendor</directory>
-      <directory suffix=".php">tests</directory>
-    </blacklist>
-  </filter>
 </phpunit>

--- a/tests/PackagistTest.php
+++ b/tests/PackagistTest.php
@@ -1,7 +1,8 @@
 <?php
-use \Jleagle\Packagist;
+use Jleagle\Packagist;
+use PHPUnit\Framework\TestCase;
 
-class PackagistTest extends PHPUnit_Framework_TestCase
+class PackagistTest extends TestCase
 {
 
   /**
@@ -11,7 +12,7 @@ class PackagistTest extends PHPUnit_Framework_TestCase
    */
   public function testPackage()
   {
-    $packagist = new Packagist('http://packagist.org');
+    $packagist = new Packagist();
     $package = $packagist->package('jleagle/packagist-api-client');
 
     $this->assertArrayHasKey('versions', $package);
@@ -23,8 +24,8 @@ class PackagistTest extends PHPUnit_Framework_TestCase
    */
   public function testSearch()
   {
-    $packagist = new Packagist('http://packagist.org');
-    $search = $packagist->search();
+    $packagist = new Packagist();
+    $search = $packagist->search('packagist-api-client');
 
     $this->assertArrayHasKey('results', $search);
     $this->assertArrayHasKey('pages', $search);
@@ -36,14 +37,14 @@ class PackagistTest extends PHPUnit_Framework_TestCase
    */
   public function testAll()
   {
-    $packagist = new Packagist('http://packagist.org');
+    $packagist = new Packagist();
 
     $all = $packagist->all();
-    $this->assertTrue(in_array('jleagle/packagist-api-client', $all));
+    $this->assertContains('jleagle/packagist-api-client', $all);
 
     $filtered = $packagist->all('*zend*');
-    $this->assertTrue(in_array('zendframework/zend-authentication', $filtered));
-    $this->assertFalse(in_array('jleagle/packagist-api-client', $filtered));
+    $this->assertContains('zendframework/zend-authentication', $filtered);
+    $this->assertNotContains('jleagle/packagist-api-client', $filtered);
   }
 
   /**
@@ -53,9 +54,9 @@ class PackagistTest extends PHPUnit_Framework_TestCase
    */
   public function testPackageException()
   {
-    $this->setExpectedException('Exception');
+    $this->expectException('Exception');
 
-    $packagist = new Packagist('http://packagist.org');
+    $packagist = new Packagist();
     $package = $packagist->package('xxx');
   }
 }


### PR DESCRIPTION
fixed jleagle/packagist-api-client#2 - PHP 8.1 Deprecation - Illuminate\Support\Collection

Updated "vinelab/rss": "^2.0"
Updated "phpunit/phpunit": "^9.3.0"
Fixed phpunit.xml warnings from current phpunit standards
Fixed \PackagistTest failing tests and updated to current phpunit standards